### PR TITLE
Jerome/double start test

### DIFF
--- a/battery_test.py
+++ b/battery_test.py
@@ -139,8 +139,6 @@ class MainTestWindow(QMainWindow):
 			self.mp_process_list[ch_num].start()
 		except:
 			traceback.print_exc()
-		finally:
-			self.mp_process_list[ch_num].join()
 
 
 def main():

--- a/battery_test.py
+++ b/battery_test.py
@@ -4,6 +4,7 @@ from PyQt6.QtWidgets import QApplication, QMainWindow, QPushButton, QLabel, QVBo
 from multiprocessing import Process, Queue
 from functools import partial
 import queue #queue module required for exception handling of multiprocessing.Queue
+import traceback
 
 import charge_discharge_control as cdc
 import equipment as eq
@@ -121,13 +122,17 @@ class MainTestWindow(QMainWindow):
 		
 	
 	def batt_test_process(self, res_ids_dict, data_out_queue = None, ch_num = None):
-		# TODO: Handle res_ids_dict = None
-		if self.mp_process_list[ch_num] is not None and self.mp_process_list[ch_num].is_alive():
-			print(f"There is a process already running")
-			return
-		self.mp_process_list[ch_num] = Process(target=cdc.charge_discharge_control, args = (res_ids_dict, data_out_queue))
-		self.mp_process_list[ch_num].start()
-		self.mp_process_list[ch_num].join()
+		try:
+			# TODO: Handle res_ids_dict = None
+			if self.mp_process_list[ch_num] is not None and self.mp_process_list[ch_num].is_alive():
+				print(f"There is a process already running")
+				return
+			self.mp_process_list[ch_num] = Process(target=cdc.charge_discharge_control, args = (res_ids_dict, data_out_queue))
+			self.mp_process_list[ch_num].start()
+		except:
+			traceback.print_exc()
+		finally:
+			self.mp_process_list[ch_num].join()
 
 
 def main():

--- a/battery_test.py
+++ b/battery_test.py
@@ -90,40 +90,48 @@ class MainTestWindow(QMainWindow):
 			
 	
 	def assign_equipment(self, ch_num):
-		#choose a psu and eload for each channel
-		msg = "Do you want to connect a power supply for channel {}?".format(ch_num)
-		title = "Power Supply Connection"
-		if eg.ynbox(msg, title):
-			self.psu_ch_list[ch_num] = eq.powerSupplies.choose_psu()
-		msg = "Do you want to connect an eload for channel {}?".format(ch_num)
-		title = "Eload Connection"
-		if eg.ynbox(msg, title):
-			self.eload_ch_list[ch_num] = eq.eLoads.choose_eload()
-		
-		#Separate measurement devices
-		msg = "Do you want to use a separate device to measure voltage on channel {}?".format(ch_num)
-		title = "Voltage Measurement Device"
-		if eg.ynbox(msg, title):
-			self.dmm_v_ch_list[ch_num] = eq.dmms.choose_dmm()
-		msg = "Do you want to use a separate device to measure current on channel {}?".format(ch_num)
-		title = "Current Measurement Device"
-		if eg.ynbox(msg, title):
-			self.dmm_i_ch_list[ch_num] = eq.dmms.choose_dmm()
+		try:
+			#choose a psu and eload for each channel
+			msg = "Do you want to connect a power supply for channel {}?".format(ch_num)
+			title = "Power Supply Connection"
+			if eg.ynbox(msg, title):
+				self.psu_ch_list[ch_num] = eq.powerSupplies.choose_psu()
+			msg = "Do you want to connect an eload for channel {}?".format(ch_num)
+			title = "Eload Connection"
+			if eg.ynbox(msg, title):
+				self.eload_ch_list[ch_num] = eq.eLoads.choose_eload()
+			
+			#Separate measurement devices
+			msg = "Do you want to use a separate device to measure voltage on channel {}?".format(ch_num)
+			title = "Voltage Measurement Device"
+			if eg.ynbox(msg, title):
+				self.dmm_v_ch_list[ch_num] = eq.dmms.choose_dmm()
+			msg = "Do you want to use a separate device to measure current on channel {}?".format(ch_num)
+			title = "Current Measurement Device"
+			if eg.ynbox(msg, title):
+				self.dmm_i_ch_list[ch_num] = eq.dmms.choose_dmm()
 
-		self.batt_ch_list[ch_num].assign_equipment(psu_to_assign = self.psu_ch_list[ch_num], eload_to_assign = self.eload_ch_list[ch_num],
-									  dmm_v_to_assign = self.dmm_v_ch_list[ch_num], dmm_i_to_assign = self.dmm_i_ch_list[ch_num])
-		
-		self.res_ids_dict_list[ch_num] = self.batt_ch_list[ch_num].get_assigned_eq_res_ids()
+			self.batt_ch_list[ch_num].assign_equipment(psu_to_assign = self.psu_ch_list[ch_num], eload_to_assign = self.eload_ch_list[ch_num],
+										dmm_v_to_assign = self.dmm_v_ch_list[ch_num], dmm_i_to_assign = self.dmm_i_ch_list[ch_num])
+			
+			self.res_ids_dict_list[ch_num] = self.batt_ch_list[ch_num].get_assigned_eq_res_ids()
 
-		self.batt_ch_list[ch_num].disconnect_all_assigned_eq()
+			self.batt_ch_list[ch_num].disconnect_all_assigned_eq()
+		except:
+			print("Something went wrong with assigning equipment. Please try again.")
+			return
+
 
 	def start_test(self, ch_num):
 		self.batt_test_process(self.res_ids_dict_list[ch_num], data_out_queue = self.data_from_ch_queue_list[ch_num], ch_num = ch_num)
 		
 	
 	def batt_test_process(self, res_ids_dict, data_out_queue = None, ch_num = None):
+		if res_ids_dict == None:
+			print("Please Assign Equipment to this Channel before starting a test!")
+			return
+
 		try:
-			# TODO: Handle res_ids_dict = None
 			if self.mp_process_list[ch_num] is not None and self.mp_process_list[ch_num].is_alive():
 				print(f"There is a process already running")
 				return

--- a/battery_test.py
+++ b/battery_test.py
@@ -133,7 +133,7 @@ class MainTestWindow(QMainWindow):
 
 		try:
 			if self.mp_process_list[ch_num] is not None and self.mp_process_list[ch_num].is_alive():
-				print(f"There is a process already running")
+				print(f"There is a process already running in Channel {ch_num}")
 				return
 			self.mp_process_list[ch_num] = Process(target=cdc.charge_discharge_control, args = (res_ids_dict, data_out_queue))
 			self.mp_process_list[ch_num].start()

--- a/charge_discharge_control.py
+++ b/charge_discharge_control.py
@@ -9,6 +9,7 @@ import easygui as eg
 import os
 import Templates
 import FileIO
+import traceback
 
 
 ##################### EQUIPMENT SETUP ####################
@@ -513,119 +514,120 @@ def ask_storage_charge():
 ################################## BATTERY CYCLING SETUP FUNCTION ######################################
 
 def charge_discharge_control(res_ids_dict, data_out_queue = None):
-	
 	eq_dict = dict()
-	for key in res_ids_dict:
-		if res_ids_dict[key]['res_id'] != None:
-			eq_dict[key] = eq.connect_to_eq(key, res_ids_dict[key]['class_name'], res_ids_dict[key]['res_id'])
-		else:
-			eq_dict[key] = None
-	
-	#get the cell name
-	cell_name = eg.enterbox(title = "Test Setup", msg = "Enter the Cell Name\n(Spaces will be replaced with underscores)",
-							default = "CELL_NAME", strip = True)
-	#replace the spaces to keep file names consistent
-	cell_name = cell_name.replace(" ", "_")
-	
-	#Get a directory to save the file
-	directory = FileIO.get_directory("Choose directory to save the cycle logs")
-	
-	#different cycle types that are available
-	cycle_types = Templates.CycleTypes.cycle_types
-	cycle_types["Single CC Cycle"]['func_call'] = single_cc_cycle_info
-	cycle_types["One Setting Continuous CC Cycles With Rest"]['func_call'] = one_level_continuous_cc_cycles_with_rest_info
-	cycle_types["Two Setting Continuous CC Cycles With Rest"]['func_call'] = two_level_continuous_cc_cycles_with_rest_info
-	cycle_types["CC Charge Only"]['func_call'] = charge_only_cycle_info
-	cycle_types["CC Discharge Only"]['func_call'] = discharge_only_cycle_info
-	cycle_types["Step Cycle"]['func_call'] = multi_step_cell_info
-	cycle_types["Continuous Step Cycles"]['func_call'] = continuous_step_cycles_info
-	
-	#choose the cycle type
-	msg = "Which cycle type do you want to do?"
-	title = "Choose Cycle Type"
-	cycle_type = eg.choicebox(msg, title, list(cycle_types.keys()))
-	
-	#gather the list settings based on the cycle type
-	cycle_settings_list_of_lists = list()
-	cycle_settings_list_of_lists = cycle_types[cycle_type]['func_call']()
-	
-	#STORAGE CHARGE
-	do_a_storage_charge = False
-	if(cycle_types[cycle_type]['str_chg_opt']):
-		do_a_storage_charge = ask_storage_charge()
-	
-	#extend adds two lists, append adds a single element to a list. We want extend here since charge_only_cycle_info() returns a list.
-	if do_a_storage_charge:
-		cycle_settings_list_of_lists.extend(charge_only_cycle_info())
-	
-	#REQUIRED EQUIPMENT
-	eq_req_dict = {'psu': False, 'eload': False}
-	
-	if cycle_type in ("Step Cycle", "Continuous Step Cycles"):
-		eq_req_dict = find_eq_req_steps(cycle_settings_list_of_lists)
-	else:
-		eq_req_dict['psu'] = cycle_types[cycle_type]['supply_req']
-		eq_req_dict['eload'] = cycle_types[cycle_type]['load_req']
-
-	if eq_req_dict['eload'] and eq_dict['eload'] == None:
-		print("Eload required for cycle but none connected! Exiting")
-		return
-	
-	if eq_req_dict['psu'] and eq_dict['psu'] == None:
-		print("Power Supply required for cycle type but none connected! Exiting")
-		return
-	#TODO - check cycles with multiple types
-	
-	
-	#Now initialize all the equipment that is connected
-	if eq_dict['eload'] != None:	
-		init_eload(eq_dict['eload'])
-	if eq_dict['psu'] != None:
-		init_psu(eq_dict['psu'])
-	if eq_dict['dmm_v'] != None:
-		init_dmm_v(eq_dict['dmm_v'])
-	if eq_dict['dmm_i'] != None:
-		init_dmm_i(eq_dict['dmm_i'])
-	
-	
-	#TODO - looping a current profile until safety limits are hit
-	#TODO - current step profiles to/from csv and/or JSON files
-	
-	#cycle x times
-	cycle_num = 0
-	for cycle_settings_list in cycle_settings_list_of_lists:
-		print("Cycle {} Starting".format(cycle_num), flush=True)
-		filepath = FileIO.start_file(directory, cell_name)
+	try:
+		for key in res_ids_dict:
+			if res_ids_dict[key]['res_id'] != None:
+				eq_dict[key] = eq.connect_to_eq(key, res_ids_dict[key]['class_name'], res_ids_dict[key]['res_id'])
+			else:
+				eq_dict[key] = None
+		#get the cell name
+		cell_name = eg.enterbox(title = "Test Setup", msg = "Enter the Cell Name\n(Spaces will be replaced with underscores)",
+								default = "CELL_NAME", strip = True)
+		#replace the spaces to keep file names consistent
+		cell_name = cell_name.replace(" ", "_")
 		
-		try:
+		#Get a directory to save the file
+		directory = FileIO.get_directory("Choose directory to save the cycle logs")
+		
+		#different cycle types that are available
+		cycle_types = Templates.CycleTypes.cycle_types
+		cycle_types["Single CC Cycle"]['func_call'] = single_cc_cycle_info
+		cycle_types["One Setting Continuous CC Cycles With Rest"]['func_call'] = one_level_continuous_cc_cycles_with_rest_info
+		cycle_types["Two Setting Continuous CC Cycles With Rest"]['func_call'] = two_level_continuous_cc_cycles_with_rest_info
+		cycle_types["CC Charge Only"]['func_call'] = charge_only_cycle_info
+		cycle_types["CC Discharge Only"]['func_call'] = discharge_only_cycle_info
+		cycle_types["Step Cycle"]['func_call'] = multi_step_cell_info
+		cycle_types["Continuous Step Cycles"]['func_call'] = continuous_step_cycles_info
+		
+		#choose the cycle type
+		msg = "Which cycle type do you want to do?"
+		title = "Choose Cycle Type"
+		cycle_type = eg.choicebox(msg, title, list(cycle_types.keys()))
+		
+		#gather the list settings based on the cycle type
+		cycle_settings_list_of_lists = list()
+		cycle_settings_list_of_lists = cycle_types[cycle_type]['func_call']()
+		
+		#STORAGE CHARGE
+		do_a_storage_charge = False
+		if(cycle_types[cycle_type]['str_chg_opt']):
+			do_a_storage_charge = ask_storage_charge()
+		
+		#extend adds two lists, append adds a single element to a list. We want extend here since charge_only_cycle_info() returns a list.
+		if do_a_storage_charge:
+			cycle_settings_list_of_lists.extend(charge_only_cycle_info())
+		
+		#REQUIRED EQUIPMENT
+		eq_req_dict = {'psu': False, 'eload': False}
+		
+		if cycle_type in ("Step Cycle", "Continuous Step Cycles"):
+			eq_req_dict = find_eq_req_steps(cycle_settings_list_of_lists)
+		else:
+			eq_req_dict['psu'] = cycle_types[cycle_type]['supply_req']
+			eq_req_dict['eload'] = cycle_types[cycle_type]['load_req']
+
+		if eq_req_dict['eload'] and eq_dict['eload'] == None:
+			print("Eload required for cycle but none connected! Exiting")
+			return
+		
+		if eq_req_dict['psu'] and eq_dict['psu'] == None:
+			print("Power Supply required for cycle type but none connected! Exiting")
+			return
+		#TODO - check cycles with multiple types
+		
+		
+		#Now initialize all the equipment that is connected
+		if eq_dict['eload'] != None:	
+			init_eload(eq_dict['eload'])
+		if eq_dict['psu'] != None:
+			init_psu(eq_dict['psu'])
+		if eq_dict['dmm_v'] != None:
+			init_dmm_v(eq_dict['dmm_v'])
+		if eq_dict['dmm_i'] != None:
+			init_dmm_i(eq_dict['dmm_i'])
+		
+		
+		#TODO - looping a current profile until safety limits are hit
+		#TODO - current step profiles to/from csv and/or JSON files
+		
+		#cycle x times
+		cycle_num = 0
+		for cycle_settings_list in cycle_settings_list_of_lists:
+			print("Cycle {} Starting".format(cycle_num), flush=True)
+			filepath = FileIO.start_file(directory, cell_name)
 			
-			for cycle_settings in cycle_settings_list:
-				#Charge only - only using the power supply
-				if isinstance(cycle_settings, Templates.ChargeSettings):
-					charge_cycle(filepath, cycle_settings.settings, eq_dict['psu'], v_meas_eq = eq_dict['dmm_v'], i_meas_eq = eq_dict['dmm_i'], data_out_queue = data_out_queue)
-					
-				#Discharge only - only using the eload
-				elif isinstance(cycle_settings, Templates.DischargeSettings):
-					discharge_cycle(filepath, cycle_settings.settings, eq_dict['eload'], v_meas_eq = eq_dict['dmm_v'], i_meas_eq = eq_dict['dmm_i'], data_out_queue = data_out_queue)
+			try:
 				
-				#Step Functions
-				elif isinstance(cycle_settings, Templates.StepSettings):
-					end_condition = single_step_cycle(filepath, cycle_settings.settings, eload = eq_dict['eload'], psu = eq_dict['psu'], v_meas_eq = eq_dict['dmm_v'], i_meas_eq = eq_dict['dmm_i'], data_out_queue = data_out_queue)
-					if end_condition == 'safety_condition':
-						break
+				for cycle_settings in cycle_settings_list:
+					#Charge only - only using the power supply
+					if isinstance(cycle_settings, Templates.ChargeSettings):
+						charge_cycle(filepath, cycle_settings.settings, eq_dict['psu'], v_meas_eq = eq_dict['dmm_v'], i_meas_eq = eq_dict['dmm_i'], data_out_queue = data_out_queue)
 						
-				#Cycle the cell - using both psu and eload
-				else:
-					cycle_cell(filepath, cycle_settings.settings, eq_dict['eload'], eq_dict['psu'], v_meas_eq = eq_dict['dmm_v'], i_meas_eq = eq_dict['dmm_i'], data_out_queue = data_out_queue)
-			
-		except KeyboardInterrupt:
-			disable_equipment(psu = eq_dict['psu'], eload = eq_dict['eload'])
-			exit()
-		cycle_num += 1
-	
-	disable_equipment(psu = eq_dict['psu'], eload = eq_dict['eload'])
-	
-	print("All Cycles Completed")
+					#Discharge only - only using the eload
+					elif isinstance(cycle_settings, Templates.DischargeSettings):
+						discharge_cycle(filepath, cycle_settings.settings, eq_dict['eload'], v_meas_eq = eq_dict['dmm_v'], i_meas_eq = eq_dict['dmm_i'], data_out_queue = data_out_queue)
+					
+					#Step Functions
+					elif isinstance(cycle_settings, Templates.StepSettings):
+						end_condition = single_step_cycle(filepath, cycle_settings.settings, eload = eq_dict['eload'], psu = eq_dict['psu'], v_meas_eq = eq_dict['dmm_v'], i_meas_eq = eq_dict['dmm_i'], data_out_queue = data_out_queue)
+						if end_condition == 'safety_condition':
+							break
+							
+					#Cycle the cell - using both psu and eload
+					else:
+						cycle_cell(filepath, cycle_settings.settings, eq_dict['eload'], eq_dict['psu'], v_meas_eq = eq_dict['dmm_v'], i_meas_eq = eq_dict['dmm_i'], data_out_queue = data_out_queue)
+				
+			except KeyboardInterrupt:
+				disable_equipment(psu = eq_dict['psu'], eload = eq_dict['eload'])
+				exit()
+			cycle_num += 1
+		
+		disable_equipment(psu = eq_dict['psu'], eload = eq_dict['eload'])
+
+		print("All Cycles Completed")
+	except Exception:
+		traceback.print_exc()
 
 ####################################### MAIN PROGRAM ######################################
 

--- a/charge_discharge_control.py
+++ b/charge_discharge_control.py
@@ -649,7 +649,6 @@ class BatteryChannel:
 	
 	def get_assigned_eq_res_ids(self):
 		eq_res_ids_dict = dict()
-		#TODO - starting a second test - won't be able to use inst as the resource is already closed.
 		for key in self.eq_dict:
 			eq_res_ids_dict[key] = {'class_name': None, 'res_id': None}
 			if self.eq_dict[key] != None:

--- a/equipment.py
+++ b/equipment.py
@@ -1,6 +1,7 @@
 #contains a list of all the equipment that there are libraries for
 #organized into which ones have common function calls
 import easygui as eg
+from easygui.boxes.derived_boxes import msgbox
 
 #Eloads
 from lab_equipment import Eload_BK8600
@@ -47,6 +48,10 @@ class eLoads:
 			msg = "In which series is the E-Load?"
 			title = "E-Load Series Selection"
 			class_name = eg.choicebox(msg, title, eLoads.part_numbers.keys())
+
+		if class_name == None:
+			msgbox("Failed to select the equipment.")
+			return			
 		
 		if(class_name == 'BK8600'):
 			eload = Eload_BK8600.BK8600(resource_id = resource_id)
@@ -75,6 +80,10 @@ class powerSupplies:
 			msg = "In which series is the PSU?"
 			title = "PSU Series Selection"
 			class_name = eg.choicebox(msg, title, powerSupplies.part_numbers.keys())
+
+		if class_name == None:
+			msgbox("Failed to select the equipment.")
+			return
 		
 		if(class_name == 'SPD1000'):
 			psu = PSU_SPD1000.SPD1000(resource_id = resource_id)
@@ -103,6 +112,10 @@ class dmms:
 			msg = "In which series is the DMM?"
 			title = "DMM Series Selection"
 			class_name = eg.choicebox(msg, title, dmms.part_numbers.keys())
+
+		if class_name == None:
+			msgbox("Failed to select the equipment.")
+			return			
 		
 		#if(class_name == 'DM3068'):
 		#	dmm = DMM_DM3068.DM3068(resource_id = resource_id)


### PR DESCRIPTION
- Storing res_ids in main window within the assign equipment function instead of the battery test function. This allows a user to press the start test button again after completing a test on a certain channel.
- Wrapped assign equipment and charge discharge control functions with a try except to catch easy gui errors. It looks like git diff doesn't handle this really well so it looks like I changed a lot of code.
- Handled some gui exception cases